### PR TITLE
Apply the `the_content` filter to the post content

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -181,7 +181,8 @@ function render_block_core_latest_posts( $attributes ) {
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
 			&& isset( $attributes['displayPostContentRadio'] ) && 'full_post' === $attributes['displayPostContentRadio'] ) {
 
-			$post_content = html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) );
+			/** This filter is documented in wp-includes/post-template.php */
+			$post_content = apply_filters( 'the_content', html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) ) );
 
 			if ( post_password_required( $post ) ) {
 				$post_content = __( 'This content is password protected.' );


### PR DESCRIPTION


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/70546

Applied the `the_content` filter to the post content.

## Why?
Allow plugins and themes to process post content as it is everywhere else on the site.

